### PR TITLE
[minor] router.Use now accepts any no.of middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![](https://godoc.org/github.com/nathany/looper?status.svg)](http://godoc.org/github.com/bnkamalesh/webgo)
 [![](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go#web-frameworks)
 
-# WebGo v5.0.0
+# WebGo v5.2.0
 
 WebGo is a minimalistic framework for [Go](https://golang.org) to build web applications (server side) with zero 3rd party dependencies. WebGo will always be Go standard library compliant; with the HTTP handlers having the same signature as [http.HandlerFunc](https://golang.org/pkg/net/http/#HandlerFunc).
 
@@ -107,8 +107,9 @@ NotFound && NotImplemented are the handlers which are considered `Special` handl
 
 ```golang
 import (
-	"github.com/bnkamalesh/webgo/v4"
-	"github.com/bnkamalesh/webgo/v4/middleware"
+	"github.com/bnkamalesh/webgo/v5"
+	"github.com/bnkamalesh/webgo/v5/middleware/accesslog"
+	"github.com/bnkamalesh/webgo/v5/middleware/cors"
 )
 
 func routes() []*webgo.Route {
@@ -134,9 +135,9 @@ func main() {
 		WriteTimeout: 60 * time.Second,
 	}, routes())
 
-	router.UseOnSpecialHandlers(middleware.AccessLog)
+	router.UseOnSpecialHandlers(accesslog.AccessLog)
 	
-	router.Use(middleware.AccessLog)
+	router.Use(accesslog.AccessLog)
 
 	router.Start()
 }
@@ -147,8 +148,8 @@ Any number of middleware can be added to the router, the order of execution of m
 
 ```golang
 func main() {
-	router.Use(middleware.AccessLog)
-	router.Use(middleware.CorsWrap())
+	router.Use(accesslog.AccessLog, cors.CORS(nil))
+	router.Use(<more middleware>)
 }
 ```
 
@@ -296,7 +297,7 @@ Usage is shown in `cmd/main.go`.
 
 ## Usage
 
-A fully functional sample is provided [here](https://github.com/bnkamalesh/webgo/blob/master/cmd/main.go). You can try the following API calls with the sample app.
+A fully functional sample is provided [here](https://github.com/bnkamalesh/webgo/blob/master/cmd/main.go). You can try the following API calls with the sample app. It also uses all the features provided by webgo
 
 1. `http://localhost:8080/`
 	- Route with no named parameters configured
@@ -313,6 +314,8 @@ A fully functional sample is provided [here](https://github.com/bnkamalesh/webgo
 	- e.g.
 		- http://localhost:8080/api/hello
 		- http://localhost:8080/api/world
+4. `http://localhost:8080/error-setter`
+	- Route which sets an error and sets response status 500
 
 ### How to run the sample
 

--- a/webgo.go
+++ b/webgo.go
@@ -26,6 +26,7 @@ const wgoCtxKey = ctxkey("webgocontext")
 // ContextPayload is the WebgoContext. A new instance of ContextPayload is injected inside every request's context object
 type ContextPayload struct {
 	Route *Route
+	Err   error
 	path  string
 }
 
@@ -37,11 +38,33 @@ func (cp *ContextPayload) Params() map[string]string {
 func (cp *ContextPayload) reset() {
 	cp.Route = nil
 	cp.path = ""
+	cp.Err = nil
+}
+
+// SetError sets the err within the context
+func (cp *ContextPayload) SetError(err error) {
+	cp.Err = err
+}
+
+// Error returns the error set within the context
+func (cp *ContextPayload) Error() error {
+	return cp.Err
 }
 
 // Context returns the ContextPayload injected inside the HTTP request context
 func Context(r *http.Request) *ContextPayload {
 	return r.Context().Value(wgoCtxKey).(*ContextPayload)
+}
+
+// SetError is a helper function to set the error in webgo context
+func SetError(r *http.Request, err error) {
+	ctx := Context(r)
+	ctx.SetError(err)
+}
+
+// GetError is a helper function to get the error from webgo context
+func GetError(r *http.Request) error {
+	return Context(r).Error()
 }
 
 // ResponseStatus returns the response status code. It works only if the http.ResponseWriter


### PR DESCRIPTION
[minor] router.Use now accepts any no.of middleware
[minor] `webgo.SetError(*http.Request, error)` & `webgo.GetError(r) error` added to support centralized error handling
[-] sample shown in cmd/main.go


closes #29 