### PR TITLE
[minor] URI patters now support multiple wildcards, you can form more…

### DIFF
--- a/route_test.go
+++ b/route_test.go
@@ -3,77 +3,8 @@ package webgo
 import (
 	"fmt"
 	"net/http"
-	"regexp"
-	"strings"
 	"testing"
 )
-
-func TestRoute_computePatternStr(t *testing.T) {
-	t.Parallel()
-	type fields struct {
-		Name                    string
-		Method                  string
-		Pattern                 string
-		TrailingSlash           bool
-		FallThroughPostResponse bool
-		Handlers                []http.HandlerFunc
-		uriKeys                 []string
-		uriPatternString        string
-		uriPattern              *regexp.Regexp
-		serve                   http.HandlerFunc
-	}
-	type args struct {
-		patternString string
-		hasWildcard   bool
-		key           string
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    string
-		wantErr bool
-	}{
-		{
-			name: "duplicate URIs",
-			fields: fields{
-				Pattern: "/a/b/:c/:c",
-				// uriKeys is initialized with a key, so as to detect duplicate key
-				uriKeys: []string{"c"},
-			},
-			args: args{
-				patternString: strings.Replace("/a/b/:c/:c", ":c", urlchars, 2),
-				hasWildcard:   false,
-				key:           "c",
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r := &Route{
-				Name:                    tt.fields.Name,
-				Method:                  tt.fields.Method,
-				Pattern:                 tt.fields.Pattern,
-				TrailingSlash:           tt.fields.TrailingSlash,
-				FallThroughPostResponse: tt.fields.FallThroughPostResponse,
-				Handlers:                tt.fields.Handlers,
-				uriKeys:                 tt.fields.uriKeys,
-				uriPatternString:        tt.fields.uriPatternString,
-				uriPattern:              tt.fields.uriPattern,
-				serve:                   tt.fields.serve,
-			}
-			got, err := r.computePatternStr(tt.args.patternString, tt.args.hasWildcard, tt.args.key)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Route.computePatternStr() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("Route.computePatternStr() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestRouteGroupsPathPrefix(t *testing.T) {
 	t.Parallel()

--- a/webgo.go
+++ b/webgo.go
@@ -35,19 +35,18 @@ const wgoCtxKey = ctxkey("webgocontext")
 
 // ContextPayload is the WebgoContext. A new instance of ContextPayload is injected inside every request's context object
 type ContextPayload struct {
-	Route *Route
-	Err   error
-	path  string
+	Route     *Route
+	Err       error
+	URIParams map[string]string
 }
 
 // Params returns the URI parameters of the respective route
 func (cp *ContextPayload) Params() map[string]string {
-	return cp.Route.params(cp.path)
+	return cp.URIParams
 }
 
 func (cp *ContextPayload) reset() {
 	cp.Route = nil
-	cp.path = ""
 	cp.Err = nil
 }
 


### PR DESCRIPTION
… patterns. e.g. all routes ending with /hello.

[-] refer to the test TestWildcardMadness in router_test.go on sample usage
[patch] there was a regression introduced while fixing trailing slash config support for wildcard routes
[-] regression was introduced after changing the regex used for route matching. Now there's no more
regex and routes are parsed with custom fns (is ~2x faster)