### PR TITLE
[major] Reverse middleware execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![](https://godoc.org/github.com/nathany/looper?status.svg)](http://godoc.org/github.com/bnkamalesh/webgo)
 [![](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go#web-frameworks)
 
-# WebGo v6.7.0
+# WebGo v7.0.0
 
 WebGo is a minimalistic router for [Go](https://golang.org) to build web applications (server side) with no 3rd party dependencies. WebGo will always be Go standard library compliant; with the HTTP handlers having the same signature as [http.HandlerFunc](https://golang.org/pkg/net/http/#HandlerFunc).
 

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -63,9 +63,9 @@ You can try the following API calls with the sample app. It also uses all the fe
      - http://localhost:8080/api/world
 4. `http://localhost:8080/error-setter`
    - Route which sets an error and sets response status 500
-5. `http://localhost:8080/v6.7/api/<param>`
+5. `http://localhost:8080/v7.0.0/api/<param>`
    - Route with a named 'param' configured
-   - It will match all requests which match `/v6.7/api/<single parameter>`
+   - It will match all requests which match `/v7.0.0/api/<single parameter>`
    - e.g.
-     - http://localhost:8080/v6.7/api/hello
-     - http://localhost:8080/v6.7/api/world
+     - http://localhost:8080/v7.0.0/api/hello
+     - http://localhost:8080/v7.0.0/api/world

--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bnkamalesh/webgo/v6"
-	"github.com/bnkamalesh/webgo/v6/extensions/sse"
+	"github.com/bnkamalesh/webgo/v7"
+	"github.com/bnkamalesh/webgo/v7/extensions/sse"
 )
 
 // StaticFilesHandler is used to serve static files
@@ -137,9 +137,10 @@ func ParamHandler(w http.ResponseWriter, r *http.Request) {
 	webgo.R200(
 		w,
 		map[string]interface{}{
-			"route":   route.Name,
-			"params":  params,
-			"chained": r.Header.Get("chained"),
+			"route_name":    route.Name,
+			"route_pattern": route.Pattern,
+			"params":        params,
+			"chained":       r.Header.Get("chained"),
 		},
 	)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bnkamalesh/webgo/v6"
-	"github.com/bnkamalesh/webgo/v6/extensions/sse"
-	"github.com/bnkamalesh/webgo/v6/middleware/accesslog"
-	"github.com/bnkamalesh/webgo/v6/middleware/cors"
+	"github.com/bnkamalesh/webgo/v7"
+	"github.com/bnkamalesh/webgo/v7/extensions/sse"
+	"github.com/bnkamalesh/webgo/v7/middleware/accesslog"
+	"github.com/bnkamalesh/webgo/v7/middleware/cors"
 )
 
 var (
@@ -123,9 +123,9 @@ func setup() (*webgo.Router, *sse.SSE) {
 		webgo.LogCfgDisableDebug,
 	)
 
-	routeGroup := webgo.NewRouteGroup("/v6.7", false)
+	routeGroup := webgo.NewRouteGroup("/v7.0.0", false)
 	routeGroup.Add(webgo.Route{
-		Name:     "router-group-prefix-v6.7_api",
+		Name:     "router-group-prefix-v7.0.0_api",
 		Method:   http.MethodGet,
 		Pattern:  "/api/:param",
 		Handlers: []http.HandlerFunc{chain, ParamHandler},
@@ -145,7 +145,12 @@ func setup() (*webgo.Router, *sse.SSE) {
 
 	router := webgo.NewRouter(cfg, routes...)
 	router.UseOnSpecialHandlers(accesslog.AccessLog)
-	router.Use(errLogger, accesslog.AccessLog, cors.CORS(nil))
+	router.Use(
+		errLogger,
+		cors.CORS(nil),
+		accesslog.AccessLog,
+	)
+
 	return router, sseService
 }
 

--- a/config.go
+++ b/config.go
@@ -31,6 +31,11 @@ type Config struct {
 
 	// ShutdownTimeout is the duration in which graceful shutdown is completed
 	ShutdownTimeout time.Duration
+
+	// ReverseMiddleware if true, will reverse the order of execution middleware
+	// from the order of it was added. e.g. router.Use(m1,m2), m2 will execute first
+	// if ReverseMiddleware is true
+	ReverseMiddleware bool
 }
 
 // Load config file from the provided filepath and validate

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/bnkamalesh/webgo/v6
+module github.com/bnkamalesh/webgo/v7
 
 go 1.19

--- a/middleware/accesslog/accesslog.go
+++ b/middleware/accesslog/accesslog.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/bnkamalesh/webgo/v6"
+	"github.com/bnkamalesh/webgo/v7"
 )
 
 // AccessLog is a middleware which prints access log to stdout

--- a/middleware/accesslog/accesslog_test.go
+++ b/middleware/accesslog/accesslog_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bnkamalesh/webgo/v6"
+	"github.com/bnkamalesh/webgo/v7"
 )
 
 func TestAccessLog(t *testing.T) {
@@ -28,6 +28,7 @@ func TestAccessLog(t *testing.T) {
 		return
 	}
 	router.Use(AccessLog)
+	router.SetupMiddleware()
 
 	url := fmt.Sprintf("http://localhost:%s/hello", port)
 	w := httptest.NewRecorder()

--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -1,9 +1,9 @@
 /*
 Package cors sets the appropriate CORS(https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
 response headers, and lets you customize. Following customizations are allowed:
-	- provide a list of allowed domains
-	- provide a list of headers
-	- set the max-age of CORS headers
+  - provide a list of allowed domains
+  - provide a list of headers
+  - set the max-age of CORS headers
 
 The list of allowed methods are
 */
@@ -16,7 +16,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/bnkamalesh/webgo/v6"
+	"github.com/bnkamalesh/webgo/v7"
 )
 
 const (

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bnkamalesh/webgo/v6"
+	"github.com/bnkamalesh/webgo/v7"
 )
 
 func TestCORSEmptyconfig(t *testing.T) {
@@ -31,6 +31,7 @@ func TestCORSEmptyconfig(t *testing.T) {
 		return
 	}
 	router.Use(CORS(&Config{TimeoutSecs: 50}))
+	router.SetupMiddleware()
 
 	url := fmt.Sprintf("http://localhost:%s/hello", port)
 	w := httptest.NewRecorder()
@@ -129,6 +130,7 @@ func TestCORSWithConfig(t *testing.T) {
 		nil,
 	)
 
+	router.SetupMiddleware()
 	router.ServeHTTP(w, req)
 
 	if w.Header().Get(headerMethods) != "GET,OPTIONS" {
@@ -230,5 +232,6 @@ func setup(port string, routes []*webgo.Route) (*webgo.Router, error) {
 		KeyFile:         "tests/ssl/server.key",
 	}
 	router := webgo.NewRouter(cfg, routes...)
+
 	return router, nil
 }

--- a/route.go
+++ b/route.go
@@ -87,7 +87,8 @@ func (r *Route) parseURIWithParams() {
 
 func (r *Route) setupMiddleware(reverse bool) {
 	if reverse {
-		for _, m := range r.middlewarelist {
+		for i := range r.middlewarelist {
+			m := r.middlewarelist[i]
 			srv := r.serve
 			r.serve = func(rw http.ResponseWriter, req *http.Request) {
 				m(rw, req, srv)

--- a/route_test.go
+++ b/route_test.go
@@ -30,9 +30,9 @@ func TestRouteGroupsPathPrefix(t *testing.T) {
 		},
 	}
 
-	const prefix = "/v6.2"
+	const prefix = "/v7.0.0"
 	expectedSkipMiddleware := true
-	rg := NewRouteGroup("/v6.2", expectedSkipMiddleware, routes...)
+	rg := NewRouteGroup("/v7.0.0", expectedSkipMiddleware, routes...)
 
 	list := rg.Routes()
 	for idx := range list {

--- a/router.go
+++ b/router.go
@@ -216,7 +216,6 @@ func (rtr *Router) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	defer releasePoolResources(crw, ctxPayload)
 	route.serve(crw, r)
-
 }
 
 // Use adds a middleware layer

--- a/router_test.go
+++ b/router_test.go
@@ -137,7 +137,6 @@ func setup(t *testing.T, port string) (*Router, error) {
 		KeyFile:         "tests/ssl/server.key",
 	}
 	router := NewRouter(cfg, getRoutes(t)...)
-	router.SetupMiddleware()
 	return router, nil
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -28,6 +28,7 @@ func TestRouter_ServeHTTP(t *testing.T) {
 	}
 	router.Use(m)
 	router.UseOnSpecialHandlers(m)
+	router.SetupMiddleware()
 
 	list := testTable()
 
@@ -136,6 +137,7 @@ func setup(t *testing.T, port string) (*Router, error) {
 		KeyFile:         "tests/ssl/server.key",
 	}
 	router := NewRouter(cfg, getRoutes(t)...)
+	router.SetupMiddleware()
 	return router, nil
 }
 


### PR DESCRIPTION
[-] Middleware execution now is in the order of how it was added; unlike before which was LIFO (Last In First Out). The default execution order is the same order as how it was added. This is made configurable for the edge case where there's a need to reverse the order. Or for migration from an older version.